### PR TITLE
Improve dataset download with retry and timeout handling

### DIFF
--- a/R/mockDatasets.R
+++ b/R/mockDatasets.R
@@ -226,7 +226,7 @@ downloadMockDataset <- function(datasetName = "GiBleed",
     url = url,
     destfile = datasetFile,
     datasetName = datasetName,
-    timeout = old_timeout
+    timeout = max(120, old_timeout)
   )
 
   if (!firstAttempt && rlang::is_interactive()) {
@@ -491,7 +491,7 @@ filterToVocab <- function(path) {
 
 ##attemptDownload
 attemptDownload <- function(url, destfile, datasetName,
-                            timeout = 300,
+                            timeout = 120,
                             quiet = TRUE) {
   # validate basic inputs
   url <- as.character(url)


### PR DESCRIPTION
Refactors the dataset download logic to use a new attemptDownload() helper, allowing for configurable timeouts and interactive retry on failure. Enhances user feedback for network issues and provides clearer instructions for manual download if needed. Updates timeout suggestion in isMockDatasetDownloaded().