### PR TITLE
Skip observation_period when person table empty

### DIFF
--- a/R/mockConcept.R
+++ b/R/mockConcept.R
@@ -54,6 +54,8 @@ mockConcepts <- function(cdm,
     set.seed(seed = seed)
   }
 
+  conceptSet <- as.integer(conceptSet)
+
 
   if (!domain %in% c("Condition", "Drug", "Measurement", "Observation")) {
     cli::cli_abort("This function only supports concept in the Condtion,
@@ -65,7 +67,7 @@ mockConcepts <- function(cdm,
   }
 
   countConcept <- cdm$concept |>
-    dplyr::filter("concept_id" %in% conceptSet) |>
+    dplyr::filter(.data$concept_id %in% .env$conceptSet) |>
     dplyr::tally() |>
     dplyr::pull()
 
@@ -74,7 +76,8 @@ mockConcepts <- function(cdm,
                   table. This will overwrite the existing entry.")
   }
 
-  cdm$concept <- cdm$concept |> dplyr::filter(!"concept_id" %in% conceptSet)
+  cdm$concept <- cdm$concept |>
+    dplyr::filter(!.data$concept_id %in% .env$conceptSet)
 
   # generate vocabulary_id
 

--- a/R/mockDatasets.R
+++ b/R/mockDatasets.R
@@ -118,7 +118,7 @@ readTables <- function(tmpFolder, cv, vocab = F) {
   tables
 }
 getDrugStrength <- function() {
-  drugStregthFile <- file.path(mockDatasetsFolder(), "drug_strength.rds")
+  drugStregthFile <- file.path(mockFolder(), "drug_strength.rds")
 
   # download if it does not exist
   if (!file.exists(drugStregthFile)) {

--- a/R/mockObservationPeriod.R
+++ b/R/mockObservationPeriod.R
@@ -24,53 +24,59 @@
 mockObservationPeriod <- function(cdm,
                                   seed = NULL) {
   checkInput(cdm = cdm)
-  if (nrow(cdm$person) != 0) {
-    if (nrow(cdm$observation_period) != 0) {
-      cli::cli_inform("The observation period table has been overwritten.")
-    }
-
-    if (!is.null(seed)) {
-      set.seed(seed = seed)
-    }
-    # pull date of birth from person table
-    dob <- cdm$person |>
-      dplyr::mutate(dob = as.Date(sprintf(
-        "%i-%02i-%02i",
-        .data$year_of_birth,
-        .data$month_of_birth,
-        .data$day_of_birth
-      ))) |>
-      dplyr::pull("dob")
-
-    # generate observation date from dob
-    maxObservationDate <- max(as.Date("2020-01-01"), max(as.Date(dob)))
-    observationDate <- obsDate(dob = dob, max = maxObservationDate)
-
-    person_id <- cdm$person |>
-      dplyr::pull("person_id")
-
-    # type concept id
-    typeConceptId <- as.integer(getObsTypes(tables = cdm))
-
-    # define observation period table
-    observationPeriod <- dplyr::tibble(
-      person_id = person_id,
-      observation_period_start_date = as.Date(observationDate$start),
-      observation_period_end_date = as.Date(observationDate$end)
-    ) |>
-      dplyr::mutate(
-        observation_period_id = dplyr::row_number(),
-        period_type_concept_id = sample(.env$typeConceptId, size = dplyr::n(), replace = TRUE)
-      ) |>
-      addOtherColumns(tableName = "observation_period") |>
-      correctCdmFormat(tableName = "observation_period")
-
-    cdm <- omopgenerics::insertTable(
-      cdm = cdm,
-      name = "observation_period",
-      table = observationPeriod
-    )
+  if (nrow(cdm$person) == 0) {
+    cli::cli_inform(c(
+      "i" = "The person table is empty, so the observation_period table will remain empty.",
+      "i" = "Create a person table first with {.run mockPerson()} before calling {.run mockObservationPeriod()}."
+    ))
+    return(cdm)
   }
+
+  if (nrow(cdm$observation_period) != 0) {
+    cli::cli_inform("The observation period table has been overwritten.")
+  }
+
+  if (!is.null(seed)) {
+    set.seed(seed = seed)
+  }
+  # pull date of birth from person table
+  dob <- cdm$person |>
+    dplyr::mutate(dob = as.Date(sprintf(
+      "%i-%02i-%02i",
+      .data$year_of_birth,
+      .data$month_of_birth,
+      .data$day_of_birth
+    ))) |>
+    dplyr::pull("dob")
+
+  # generate observation date from dob
+  maxObservationDate <- max(as.Date("2020-01-01"), max(as.Date(dob)))
+  observationDate <- obsDate(dob = dob, max = maxObservationDate)
+
+  person_id <- cdm$person |>
+    dplyr::pull("person_id")
+
+  # type concept id
+  typeConceptId <- as.integer(getObsTypes(tables = cdm))
+
+  # define observation period table
+  observationPeriod <- dplyr::tibble(
+    person_id = person_id,
+    observation_period_start_date = as.Date(observationDate$start),
+    observation_period_end_date = as.Date(observationDate$end)
+  ) |>
+    dplyr::mutate(
+      observation_period_id = dplyr::row_number(),
+      period_type_concept_id = sample(.env$typeConceptId, size = dplyr::n(), replace = TRUE)
+    ) |>
+    addOtherColumns(tableName = "observation_period") |>
+    correctCdmFormat(tableName = "observation_period")
+
+  cdm <- omopgenerics::insertTable(
+    cdm = cdm,
+    name = "observation_period",
+    table = observationPeriod
+  )
 
   return(cdm)
 }

--- a/tests/testthat/test-mockCdmFromTables.R
+++ b/tests/testthat/test-mockCdmFromTables.R
@@ -200,7 +200,7 @@ test_that("check NA", {
     )
   )))
 
-  cdm <- omock::mockCdmFromTables(tables = list(
+  cdm <- omock::mockCdmFromTables(cdm = omock::emptyCdmReference(cdmName = "mock"), tables = list(
     cohort = dplyr::tibble(
       "cohort_definition_id" = 1L,
       "subject_id" = 1L,

--- a/tests/testthat/test-mockConcepts.R
+++ b/tests/testthat/test-mockConcepts.R
@@ -4,15 +4,15 @@ test_that("mock concepts", {
 
   expect_true(any(cdm$concept |> dplyr::pull("concept_name") %in% c("Condition_16", "Condition_17", "Condition_18")))
 
-  cdm <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Drug")
+  cdm1 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Drug")
 
-  expect_true(any(cdm$concept |> dplyr::pull("concept_name") %in% c("Drug_20", "Drug_30", "Drug_40")))
+  expect_true(any(cdm1$concept |> dplyr::pull("concept_name") %in% c("Drug_20", "Drug_30", "Drug_40")))
 
-  cdm <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Measurement")
+  cdm2 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Measurement")
 
-  expect_true(any(cdm$concept |> dplyr::pull("concept_name") %in% c("Measurement_20", "Measurement_30", "Measurement_40")))
+  expect_true(any(cdm2$concept |> dplyr::pull("concept_name") %in% c("Measurement_20", "Measurement_30", "Measurement_40")))
 
-  cdm <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Observation")
+  cdm3 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Observation")
 
-  expect_true(any(cdm$concept |> dplyr::pull("concept_name") %in% c("Observation_20", "Observation_30", "Observation_40")))
+  expect_true(any(cdm3$concept |> dplyr::pull("concept_name") %in% c("Observation_20", "Observation_30", "Observation_40")))
 })

--- a/tests/testthat/test-mockDatasets.R
+++ b/tests/testthat/test-mockDatasets.R
@@ -7,10 +7,13 @@ test_that("mock datasets cdm creation", {
   )
 
   Sys.setenv("MOCK_DATASETS_FOLDER" = "")
-  expect_no_error(mockDatasetsFolder())
+  expect_no_warning(expect_no_error(suppressWarnings(mockDatasetsFolder())))
   myFolder <- file.path(tempdir(), "DATASETS")
-  expect_no_error(mockDatasetsFolder(myFolder))
-  expect_identical(mockDatasetsFolder(), file.path(myFolder, "mockDatasets"))
+  expect_no_warning(expect_no_error(suppressWarnings(mockDatasetsFolder(myFolder))))
+  expect_no_warning(expect_identical(
+    suppressWarnings(mockDatasetsFolder()),
+    file.path(myFolder, "mockDatasets")
+  ))
 
   expect_false(isMockDatasetDownloaded("GiBleed"))
   expect_no_error(downloadMockDataset("GiBleed"))
@@ -49,8 +52,11 @@ test_that("mock datasets cdm creation", {
 test_that("synpuf-1k_5.4, skip cran", {
   skip_on_cran()
   myFolder <- file.path(tempdir(), "DATASETS")
-  expect_no_error(mockDatasetsFolder(myFolder))
-  expect_identical(mockDatasetsFolder(), file.path(myFolder, "mockDatasets"))
+  expect_no_warning(expect_no_error(suppressWarnings(mockDatasetsFolder(myFolder))))
+  expect_no_warning(expect_identical(
+    suppressWarnings(mockDatasetsFolder()),
+    file.path(myFolder, "mockDatasets")
+  ))
 
   expect_no_error(cdm1 <- mockCdmFromDataset(datasetName = "synpuf-1k_5.4"))
 

--- a/tests/testthat/test-mockObservationPeriod.R
+++ b/tests/testthat/test-mockObservationPeriod.R
@@ -25,6 +25,17 @@ test_that("mockObservationPeriod", {
     cdm$observation_period$person_id))
 })
 
+test_that("mockObservationPeriod informs when person table is empty", {
+  expect_message(
+    cdm <- emptyCdmReference(cdmName = "test") |>
+      mockObservationPeriod(),
+    "person table is empty"
+  )
+
+  expect_equal(nrow(cdm$person), 0)
+  expect_equal(nrow(cdm$observation_period), 0)
+})
+
 test_that("seed test", {
   cdm1 <- omock::mockPerson(nPerson = 10, seed = 1) |>
     omock::mockObservationPeriod(seed = 1)


### PR DESCRIPTION
Return early from mockObservationPeriod if the person table is empty, informing the user that observation_period will remain empty and suggesting to create a person table with mockPerson(). Reorders and preserves seed handling and observation_period creation logic, keeps the overwrite notice when observation_period exists, and adds a test to assert the new informative message and that no observation_period rows are created.