### PR TITLE
Validate observation dates and add Type Concept

### DIFF
--- a/R/mockCdmFromTables.R
+++ b/R/mockCdmFromTables.R
@@ -89,10 +89,12 @@ mockCdmFromTables <- function(cdm = mockCdmReference(),
   # append cdm tables to tables
   tables <- mergeTables(tables, cdm)
 
+  validateObservationDates(tables)
+
   # summarise individuals observation
   individuals <- summariseObservations(tables)
 
-  if (max(individuals$last_observation) > maxObservationalPeriodEndDate) {
+  if (max(individuals$last_observation, na.rm = TRUE) > maxObservationalPeriodEndDate) {
     cli::cli_abort(
       "tables provided contain date greater than `maxObservationalPeriodEndDate`",
       call = parent.frame()
@@ -255,6 +257,48 @@ getEndDate <- function(tableName) {
   }
   return(x)
 }
+validateObservationDates <- function(tables, call = parent.frame()) {
+  missingDates <- character()
+
+  for (k in seq_along(tables)) {
+    tableName <- names(tables)[k]
+
+    if (tableName == "person") {
+      next
+    }
+
+    personId <- getPersonId(tableName)
+
+    if (!is.na(personId)) {
+      dateColumns <- unique(c(getStartDate(tableName), getEndDate(tableName)))
+      dateColumns <- dateColumns[dateColumns %in% colnames(tables[[k]])]
+      colsWithMissingDates <- dateColumns[purrr::map_lgl(
+        dateColumns,
+        ~ any(is.na(tables[[k]][[.x]]))
+      )]
+
+      if (length(colsWithMissingDates) > 0) {
+        missingDates <- c(
+          missingDates,
+          paste0(tableName, "$", colsWithMissingDates)
+        )
+      }
+    }
+  }
+
+  if (length(missingDates) > 0) {
+    cli::cli_abort(
+      c(
+        "Input tables contain missing dates in columns used to derive observation periods.",
+        "i" = "Provide non-missing values for these date columns or remove the affected records.",
+        "x" = "{missingDates}"
+      ),
+      call = call
+    )
+  }
+
+  return(invisible(NULL))
+}
 summariseObservations <- function(tables) {
   individuals <- dplyr::tibble(
     "person_id" = integer(), "date" = as.Date(character())
@@ -316,8 +360,8 @@ summariseObservations <- function(tables) {
   individuals <- individuals |>
     dplyr::group_by(.data$person_id) |>
     dplyr::summarise(
-      "first_observation" = min(.data$date),
-      "last_observation" = max(.data$date)
+      "first_observation" = min(.data$date, na.rm = TRUE),
+      "last_observation" = max(.data$date, na.rm = TRUE)
     )
 
   return(individuals)

--- a/R/vocabularySubset.R
+++ b/R/vocabularySubset.R
@@ -27,7 +27,7 @@ subsetVocabularyTables <- function(cdm = NULL,
                                    conceptSet = NULL,
                                    cdmTables = NULL,
                                    includeRelated = TRUE,
-                                   keepDomains = c("Unit", "Visit", "Gender")) {
+                                   keepDomains = c("Unit", "Visit", "Gender", "Type Concept")) {
   if (is.null(cdmTables)) {
     if (is.null(cdm)) {
       cli::cli_abort("Either `cdm` or `cdmTables` must be supplied.")

--- a/man/subsetVocabularyTables.Rd
+++ b/man/subsetVocabularyTables.Rd
@@ -9,7 +9,7 @@ subsetVocabularyTables(
   conceptSet = NULL,
   cdmTables = NULL,
   includeRelated = TRUE,
-  keepDomains = c("Unit", "Visit", "Gender")
+  keepDomains = c("Unit", "Visit", "Gender", "Type Concept")
 )
 }
 \arguments{

--- a/tests/testthat/test-mockCdmFromTables.R
+++ b/tests/testthat/test-mockCdmFromTables.R
@@ -119,6 +119,32 @@ test_that("check cdm object get created", {
 
 
 test_that("check NA", {
+  expect_error(
+    omock::mockCdmFromTables(
+      tables = list(
+        person = dplyr::tibble(
+          person_id = 1:3L,
+          gender_concept_id = 0L,
+          year_of_birth = 2000L
+        ),
+        drug_exposure = dplyr::tibble(
+          person_id = 1:2L,
+          drug_exposure_start_date = as.Date("2020-01-01"),
+          drug_exposure_end_date = as.Date("2020-01-01")
+        ),
+        condition_occurrence = dplyr::tibble(
+          person_id = 4L,
+          condition_start_date = as.Date("2020-01-01")
+        ),
+        measurement = dplyr::tibble(
+          person_id = c(1L, 3L, 5L, 7L, 8L),
+          measurement_date = as.Date("2020-01-01")
+        )
+      )
+    ),
+    "condition_occurrence\\$condition_end_date"
+  )
+
   expect_error(omock::mockCdmFromTables(
     tables = list(
       visit_occurrence = dplyr::tibble(


### PR DESCRIPTION
Add validateObservationDates() to check for missing start/end date columns in CDM tables (excluding person) and abort with a clear message; call it from mockCdmFromTables(). Fix NA handling by using na.rm = TRUE in summariseObservations and in the max() check against maxObservationalPeriodEndDate. Add a unit test to assert missing-date errors. Also update default vocabulary keepDomains to include "Type Concept" and update the Rd documentation accordingly.