### PR TITLE
Deprecate mockConcepts and update tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # omock (development version)
 
+-   Deprecated `mockConcepts()` because it creates placeholder concept rows that
+    may be mistaken for real OMOP vocabulary content. Use
+    `mockCdmReference(vocabularySet = "eunomia")`, `mockVocabularyTables()`, or
+    `subsetVocabularyTables()` instead.
+
 # omock 0.6.2
 
 # omock 0.6.1

--- a/R/mockConcept.R
+++ b/R/mockConcept.R
@@ -1,12 +1,11 @@
 #' Adds mock concept data to a concept table within a Common Data Model (CDM) object.
 #'
-#' `r lifecycle::badge('experimental')`
+#' `r lifecycle::badge('deprecated')`
 #'
-#' This function inserts new concept entries into a specified domain within
-#' the concept table of a CDM object.It supports four domains: Condition, Drug,
-#' Measurement, and Observation. Existing entries with the same concept IDs
-#' will be overwritten, so caution should be used when adding data to prevent
-#' unintended data loss.
+#' `mockConcepts()` is deprecated because it creates placeholder concept rows
+#' that may be mistaken for real OMOP vocabulary content. Prefer using
+#' `mockCdmReference()` with `vocabularySet = "eunomia"`,
+#' `mockVocabularyTables()`, or `subsetVocabularyTables()`.
 #'
 #'
 #' @template param-cdm
@@ -42,6 +41,17 @@ mockConcepts <- function(cdm,
                          conceptSet,
                          domain = "Condition",
                          seed = NULL) {
+  lifecycle::deprecate_warn(
+    when = "0.6.2.9000",
+    what = "mockConcepts()",
+    details = paste(
+      "`mockConcepts()` creates placeholder concept rows that may be mistaken",
+      "for real OMOP vocabulary content. Use `mockCdmReference()` with",
+      "`vocabularySet = \"eunomia\"`, `mockVocabularyTables()`, or",
+      "`subsetVocabularyTables()` instead."
+    )
+  )
+
   # initial checks
   checkInput(
     cdm = cdm,

--- a/tests/testthat/test-mockConcepts.R
+++ b/tests/testthat/test-mockConcepts.R
@@ -1,18 +1,30 @@
 test_that("mock concepts", {
   cdm <- omock::mockCdmReference() |> omock::mockVocabularyTables()
-  cdm <- cdm |> omock::mockConcepts(conceptSet = c(16, 17, 18))
+  expect_warning(
+    cdm <- cdm |> omock::mockConcepts(conceptSet = c(16, 17, 18)),
+    "deprecated"
+  )
 
   expect_true(any(cdm$concept |> dplyr::pull("concept_name") %in% c("Condition_16", "Condition_17", "Condition_18")))
 
-  cdm1 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Drug")
+  expect_warning(
+    cdm1 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Drug"),
+    "deprecated"
+  )
 
   expect_true(any(cdm1$concept |> dplyr::pull("concept_name") %in% c("Drug_20", "Drug_30", "Drug_40")))
 
-  cdm2 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Measurement")
+  expect_warning(
+    cdm2 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Measurement"),
+    "deprecated"
+  )
 
   expect_true(any(cdm2$concept |> dplyr::pull("concept_name") %in% c("Measurement_20", "Measurement_30", "Measurement_40")))
 
-  cdm3 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Observation")
+  expect_warning(
+    cdm3 <- cdm |> omock::mockConcepts(conceptSet = c(20, 30, 40), domain = "Observation"),
+    "deprecated"
+  )
 
   expect_true(any(cdm3$concept |> dplyr::pull("concept_name") %in% c("Observation_20", "Observation_30", "Observation_40")))
 })


### PR DESCRIPTION
Mark mockConcepts() as deprecated: update roxygen badge to `deprecated` and add a lifecycle::deprecate_warn() with guidance to use mockCdmReference(vocabularySet = "eunomia"), mockVocabularyTables(), or subsetVocabularyTables(). Add a NEWS.md entry documenting the deprecation. Update tests to expect a deprecation warning when calling mockConcepts().